### PR TITLE
add `npm install` in `mix setup`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule ElixirJpCalendar.MixProject do
   # See the documentation for `Mix` for more info on aliases.
   defp aliases do
     [
-      setup: ["deps.get"],
+      setup: ["deps.get", "cmd npm install --prefix assets"],
       "assets.deploy": ["esbuild default --minify", "phx.digest"]
     ]
   end


### PR DESCRIPTION
Hello, thanks for this useful software !

I add `npm install` in `mix setup`.

I have the problem where having `Could not resolve "@fullcalendar"`
when git clone ...(plain) & mix setup & mix phx.server for the first time.

Hope this helps!

```
$ git clone ...
$ cd elixir_jp_calendar
$ mix setup
$ mix phx.server

[info] call https://connpass.com/api/v1/event/?count=100&order=3&series_id=5294&series_id=11907&series_id=8800&series_id=12092&series_id=11144&series_id=1632&series_id=9575&series_id=8111&series_id=7578&series_id=9138&series_id=8525&series_id=10320&series_id=9485
[info] call https://connpass.com/api/v1/event/?keyword=elixir&count=100&order=3
[info] Running ElixirJpCalendarWeb.Endpoint with cowboy 2.9.0 at 127.0.0.1:4000 (http)
[info] Access ElixirJpCalendarWeb.Endpoint at http://localhost:4000
[debug] Downloading esbuild from https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.0.tgz
 > js/app.js:5:25: error: Could not resolve "@fullcalendar/core" (mark it as external to exclude it from the bundle)
    5 │ import { Calendar } from "@fullcalendar/core";
      ╵                          ~~~~~~~~~~~~~~~~~~~~

 > js/app.js:6:21: error: Could not resolve "@fullcalendar/core/locales/ja" (mark it as external to exclude it from the bundle)
    6 │ import jaLocale from "@fullcalendar/core/locales/ja";
      ╵                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

 > js/app.js:8:26: error: Could not resolve "@fullcalendar/daygrid" (mark it as external to exclude it from the bundle)
    8 │ import dayGridPlugin from "@fullcalendar/daygrid";
      ╵                           ~~~~~~~~~~~~~~~~~~~~~~~

 > js/app.js:9:23: error: Could not resolve "@fullcalendar/list" (mark it as external to exclude it from the bundle)
    9 │ import listPlugin from "@fullcalendar/list";
      ╵                        ~~~~~~~~~~~~~~~~~~~~

4 errors
[watch] build finished, watching for changes...
```