### PR TITLE
Fix the problem where having `no match of right hand side value: nil` when get `/events?source=event`

### DIFF
--- a/lib/elixir_jp_calendar_web/params/event/index_params.ex
+++ b/lib/elixir_jp_calendar_web/params/event/index_params.ex
@@ -13,7 +13,7 @@ defmodule ElixirJpCalendarWeb.Event.IndexParams do
   end
 
   def ignore_invalid_source(%Ecto.Changeset{changes: %{source: source}} = ch) do
-    case source in ~w(event keyword) do
+    case source in ~w(#{@default_source} keyword) do
       true ->
         ch
 


### PR DESCRIPTION
Hi, team!

I fix the problem where having `no match of right hand side value: nil` when get `/events?source=event`
I might make a wrong code.

Hope this helps!